### PR TITLE
VerUP 3.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.6
+* CallManager.startCall および SwiftFlutterCallkitIncomingPlugin.startCall にオプションの completion コールバックパラメータを追加。CXCallController のトランザクションが成功し、CXProvider へのcall update報告が完了した後に completion が呼ばれます。
+
 ## 3.0.5
 * `AndroidParams` に `ongoingCallNotificationChannelName` フィールドを追加。Dart側からAndroid通話中通知チャネル名をカスタマイズできるよう対応。
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_callkit_incoming
 description: Flutter Callkit Incoming to show callkit screen in your Flutter app.
-version: 3.0.5
+version: 3.0.6
 homepage: https://github.com/hiennguyen92/flutter_callkit_incoming
 repository: https://github.com/hiennguyen92/flutter_callkit_incoming
 issue_tracker: https://github.com/hiennguyen92/flutter_callkit_incoming/issues


### PR DESCRIPTION
## 3.0.6
* CallManager.startCall および SwiftFlutterCallkitIncomingPlugin.startCall にオプションの completion コールバックパラメータを追加。CXCallController のトランザクションが成功し、CXProvider へのcall update報告が完了した後に completion が呼ばれます。